### PR TITLE
Address Ansible deprecation notices.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,24 +2,14 @@
 
 - name: Install Grok dependencies (apt)
   apt:
-    name: "{{ item }}"
+    name: ["cmake", "libpng-dev", "libtiff-dev", "liblcms2-dev"]
     update_cache: yes
     cache_valid_time: 600
-  with_items:
-    - cmake
-    - libpng-dev
-    - libtiff-dev
-    - liblcms2-dev
   when: ansible_os_family == "Debian"
 
 - name: Install Grok dependencies (yum)
   yum:
-    name: "{{ item }}"
-  with_items:
-    - cmake3
-    - libpng-devel
-    - libtiff-devel
-    - lcms2-devel
+    name: ["cmake3", "libpng-devel", "libtiff-devel", "lcms2-devel"]
   when: ansible_os_family == "RedHat"
 
 - name: Clone Grok


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1251

# What does this Pull Request do?

Moves around yaml array items to address Ansible deprecation notices.

# What's new?

Nothing.

# How should this be tested?

`vagrant up` with this PR updates, and make sure you don't see the deprecation notices outlined in https://github.com/Islandora-CLAW/CLAW/issues/1251

You will want:

This:
```
TASK [Islandora-Devops.grok : Install Grok dependencies (apt)] *****************
Friday 16 August 2019  13:54:50 -0400 (0:00:00.033)       0:57:18.937 ********* 
changed: [default]

TASK [Islandora-Devops.grok : Install Grok dependencies (yum)] *****************
Friday 16 August 2019  13:55:01 -0400 (0:00:10.934)       0:57:29.872 ********* 
skipping: [default]
```

**Not** this:
```
TASK [Islandora-Devops.grok : Install Grok dependencies (apt)] *****************
Friday 16 August 2019  12:36:28 -0400 (0:00:00.033)       0:54:49.202 ********* 
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['cmake', 'libpng-dev', 
'libtiff-dev', 'liblcms2-dev']` and remove the loop. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
changed: [default] => (item=[u'cmake', u'libpng-dev', u'libtiff-dev', u'liblcms2-dev'])

TASK [Islandora-Devops.grok : Install Grok dependencies (yum)] *****************
Friday 16 August 2019  12:36:39 -0400 (0:00:11.281)       0:55:00.484 ********* 
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['cmake3', 'libpng-
devel', 'libtiff-devel', 'lcms2-devel']` and remove the loop. This feature will
 be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
skipping: [default] => (item=[]) 
```



# Interested parties

@Islandora-Devops/committers
