### PR TITLE
Updating to grok 3.1.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 grok_clone_directory: /opt/grok
-grok_version_tag: v2.3.0
+grok_version_tag: v3.1.0


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1285

# What does this Pull Request do?

Updates Grok to v3.1.0, which does not seg fault when converting tiffs on Ubuntu 18.04 like v2.3.0 does.

# How should this be tested?

- Change the version in requirements.yml to point to this branch:
```
src: https://github.com/Islandora-Devops/ansible-role-grok
name: Islandora-Devops.grok
version: master
```
to
```
src: https://github.com/Islandora-Devops/ansible-role-grok
name: Islandora-Devops.grok
version: grok-3-1-0
```
- `rm -rf roles/external`
- `vagrant up`

After it's done building, put a Tiff in your playbook's root directory, ssh in, and run convert on it.

- `vagrant ssh`
- `cd /home/ubuntu/islandora`
- `convert my.tiff my.jp2`

No seg fault!  You can run `identify` on the resulting jp2 to confirm it's ok.

# Interested parties
@Islandora-Devops/committers
