### PR TITLE
Update to run on Ubuntu 20.04 Focal64

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 
 - name: Install Grok dependencies (apt)
   apt:
-    name: ["cmake", "libpng-dev", "libtiff-dev", "liblcms2-dev"]
+    name: ["cmake", "libpng-dev", "libtiff-dev", "liblcms2-dev", "libwebp-dev", "libzstd-dev"]
     update_cache: yes
     cache_valid_time: 600
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64](https://github.com/Islandora/documentation/issues/1792)

# What does this Pull Request do?

Update to run on Ubuntu 20.04 Focal64.

# What's new?

Add packages required to build on Ubuntu 20.04. 

# How should this be tested?

Test as part of a full playbook run on Ubuntu 20.04. Make Grok should run with no error. Adding images in Islandora should behave as expected.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
